### PR TITLE
Add GetGroupById to service and load group in MonitorService

### DIFF
--- a/TelegramMultiBot.Database/Interfaces/IMonitorDataService.cs
+++ b/TelegramMultiBot.Database/Interfaces/IMonitorDataService.cs
@@ -36,6 +36,7 @@ public interface IMonitorDataService
     Task<bool> RemoveSvitlobotKey(string key, Guid id);
     Task<IEnumerable<SvitlobotData>> GetAllSvitlobots();
     Task DeleteAllHistory();
+    Task<ElectricityGroup> GetGroupById(Guid value);
 }
 
 public class MonitorDataService(BoberDbContext context) : IMonitorDataService
@@ -355,5 +356,10 @@ public class MonitorDataService(BoberDbContext context) : IMonitorDataService
         var allRecords = context.ElectricityHistory;
         context.ElectricityHistory.RemoveRange(allRecords);
         return context.SaveChangesAsync();
+    }
+
+    public Task<ElectricityGroup> GetGroupById(Guid value)
+    {
+        return context.ElectricityGroups.FirstAsync(x => x.Id == value);
     }
 }

--- a/TelegramMultiBot/BackgroundServies/MonitorService.cs
+++ b/TelegramMultiBot/BackgroundServies/MonitorService.cs
@@ -63,6 +63,13 @@ public class MonitorService
 
                 job.LastScheduleUpdate = job.Location.LastUpdated;
 
+                if (job.GroupId.HasValue && job.Group is null)
+                {
+                    _logger.LogInformation("Loading group data for job {id} with GroupId {groupId}", job.Id, job.GroupId.Value);
+                    var groupfromDb = await dbservice.GetGroupById(job.GroupId.Value);
+                    job.Group = groupfromDb;
+                }
+
                 if (job.Group != null)
                 {
                     var oldSnapshot = job.LastSentGroupSnapsot;
@@ -83,8 +90,6 @@ public class MonitorService
                 var verifyJob = await dbservice.GetJobById(job.Id);
                 _logger.LogInformation("After DB Update - Job {id}: LastScheduleUpdate={lastSchedule}, LastSentGroupSnapsot='{snapshot}'",
                     verifyJob.Id, verifyJob.LastScheduleUpdate, verifyJob.LastSentGroupSnapsot);
-
-                await dbservice.Update(job);
 
                 await SendExisiting(job.Id);
 


### PR DESCRIPTION
Added GetGroupById method to IMonitorDataService and its implementation in MonitorDataService. Updated MonitorService to load and assign group data for jobs with a GroupId but missing Group, with logging for traceability. Removed redundant dbservice.Update(job) call.