### PR TITLE
Add monitor volume, remove watchtower, update networks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - .env
     volumes:
       - images:/app/images
+      - monitor:/app/monitor
     depends_on:
       database:
         condition: service_healthy
@@ -135,16 +136,7 @@ services:
         condition: service_healthy
         restart: true
     << : *base-config
-    
-  watchtower:
-      image: containrrr/watchtower:arm64v8-latest
-      environment:
-        DOCKER_CONFIG: /config
-      volumes:
-        - /etc/watchtower/config/:/config/
-        - /var/run/docker.sock:/var/run/docker.sock
-      command: --schedule "0 0 5 * * *" 
-      
+  
 networks:
   bober-net:
     driver: bridge
@@ -154,6 +146,8 @@ volumes:
   dbdata:
     driver: local
   images:
+    driver: local
+  monitor:
     driver: local
   dbdata-dev:
     driver: local


### PR DESCRIPTION
Added a new named volume 'monitor' and mounted it to /app/monitor. Removed the watchtower service. Introduced bober-net and bober-net-dev as bridge networks. Updated the volumes section to include the new monitor volume.