### PR TITLE
Set up /app dirs and permissions before switching user

### DIFF
--- a/TelegramMultiBot/Dockerfile
+++ b/TelegramMultiBot/Dockerfile
@@ -11,6 +11,12 @@ RUN apt-get update && apt-get install -y chromium --no-install-recommends --allo
 ######################
 ENV PUPPETEER_EXECUTABLE_PATH "/usr/bin/chromium"
 
+WORKDIR /app
+
+# Create directories and set permissions before switching to app user
+RUN mkdir -p /app/monitor /app/images && \
+    chown -R app:app /app/monitor /app/images
+
 USER app
 WORKDIR /app
 


### PR DESCRIPTION
Created /app/monitor and /app/images with app:app ownership in the Dockerfile, and set the working directory to /app before switching to the app user. This ensures required directories exist with correct permissions for the application.