### PR TITLE
Update MeTube port to 8082 in config and settings

### DIFF
--- a/TelegramMultiBot.Database/DTO/VideoDownloaderSettings.cs
+++ b/TelegramMultiBot.Database/DTO/VideoDownloaderSettings.cs
@@ -4,7 +4,7 @@ public class VideoDownloaderSettings : BaseSetting
 {
     public static string Name => "VideoDownloader";
 
-    public string MeTubeUrl { get; set; } = "http://metube:8081";
+    public string MeTubeUrl { get; set; } = "http://metube:8082";
 
     public int PollingIntervalSeconds { get; set; } = 15;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - metube-downloads:/downloads
     image: ghcr.io/alexta69/metube
     ports:
-        - "8081:8081"
+        - "8082:8081"
     restart: always
     environment:
       - YTDL_OPTIONS={"cookiesfrombrowser":null,"merge_output_format":"mp4","format":"bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best"}


### PR DESCRIPTION
Changed MeTube's host port mapping from 8081 to 8082 in docker-compose.yml and updated the MeTubeUrl in VideoDownloaderSettings to match the new port. This ensures the application connects to the correct service endpoint.