### PR TITLE
Add DownloadType to MeTubeAddRequest and set default

### DIFF
--- a/VideoDownloader/Client/MeTubeAddRequest.cs
+++ b/VideoDownloader/Client/MeTubeAddRequest.cs
@@ -43,6 +43,12 @@ public record MeTubeAddRequest
     [JsonPropertyName("chapter_template")]
     public string? ChapterTemplate { get; set; }
 
+    /// <summary>
+    /// video, audio
+    /// </summary>
+    [JsonPropertyName("download_type")]
+    public string? DownloadType { get; set; }
+
     [JsonPropertyName("folder")]
     public string? Folder { get; set; }
 

--- a/VideoDownloader/Client/MeTubeClient.cs
+++ b/VideoDownloader/Client/MeTubeClient.cs
@@ -40,6 +40,7 @@ public class MeTubeClient
             Quality = "best",
             Format = "mp4",
             Codec = "h264",
+            DownloadType = "video",
             AutoStart = true,
             SplitByChapters = false,
             CustomNamePrefix = idPrefix


### PR DESCRIPTION
Added a DownloadType property to MeTubeAddRequest to specify "video" or "audio" downloads. Updated MeTubeClient to set DownloadType to "video" by default when creating new requests.