### PR TITLE
Add yt-dlp presets support and video dimension detection

### DIFF
--- a/TelegramMultiBot/Commands/FixUrlCommand.cs
+++ b/TelegramMultiBot/Commands/FixUrlCommand.cs
@@ -1,4 +1,8 @@
 ﻿using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using PuppeteerSharp;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using TelegramMultiBot.Database;
@@ -56,31 +60,63 @@ internal class FixUrlCommand(TelegramClientWrapper client, MeTubeClient meTubeCl
             }
 
             var statusMessage = await client.SendMessageAsync(message, statusText, !canDeleteMessages, disableNotification: true);
-
+            var presets = GetPresetList(link);
             var id = Guid.NewGuid();
-            var response = await meTubeClient.AddDownload(link, id.ToString());
-            if (response?.Status == MeTubeStatus.Ok)
+
+            try
             {
-                context.VideoDownloads.Add(new VideoDownload
+                var response = await meTubeClient.AddDownload(link, id.ToString(), presets);
+                if (response?.Status == MeTubeStatus.Ok)
                 {
-                    Id = id,
-                    VideoUrl = link,
-                    ChatId = message.Chat.Id,
-                    MessageThreadId = message.IsTopicMessage ? message.MessageThreadId ?? 0 : 0,
-                    BotMessage = statusMessage.MessageId,
-                    MessageToDelete = canDeleteMessages ? message.MessageId : 0,
-                    RequestedBy = GetUserName(message.From),
-                    UserComment = userComment,
-                    CreatedAt = DateTimeOffset.UtcNow
-                });
-                await context.SaveChangesAsync();
+                    context.VideoDownloads.Add(new VideoDownload
+                    {
+                        Id = id,
+                        VideoUrl = link,
+                        ChatId = message.Chat.Id,
+                        MessageThreadId = message.IsTopicMessage ? message.MessageThreadId ?? 0 : 0,
+                        BotMessage = statusMessage.MessageId,
+                        MessageToDelete = canDeleteMessages ? message.MessageId : 0,
+                        RequestedBy = GetUserName(message.From),
+                        UserComment = userComment,
+                        CreatedAt = DateTimeOffset.UtcNow
+                    });
+                    await context.SaveChangesAsync();
+                }
+                else
+                {
+                    await client.EditMessageTextAsync(statusMessage, "❌ Не вдалося поставити відео в чергу завантаження");
+                    logger.LogError("Failed to add download for link {Link}. Response: {Response}", link, response);
+                }
             }
-            else
+            catch (Exception ex)
             {
                 await client.EditMessageTextAsync(statusMessage, "❌ Не вдалося поставити відео в чергу завантаження");
-                logger.LogError("Failed to add download for link {Link}. Response: {Response}", link, response);
+                logger.LogError("Failed to add download for link {Link}. Exception: {Exception}", link, ex.Message);
             }
         }
+    }
+
+    private string[] GetPresetList(string link)
+    {
+        var uri = new Uri(link);
+        var host = uri.Host.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        var result = new List<string>()
+        {
+            "default"
+        };
+
+        try
+        {
+            var json = JsonSerializer.Deserialize<JsonObject>(File.ReadAllText("/config/ytdl-presets.json"));
+            var availblePresets = host.Where(x => json.ContainsKey(x));
+            result.AddRange(availblePresets);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError("Failed to read perset file: {error}", ex.Message);
+        }
+
+        return result.ToArray();
     }
 
     private static string GetUserName(User? user)

--- a/VideoDownloader/Client/MeTubeAddRequest.cs
+++ b/VideoDownloader/Client/MeTubeAddRequest.cs
@@ -57,4 +57,7 @@ public record MeTubeAddRequest
 
     [JsonPropertyName("playlist_item_limit")]
     public int? PlaylistItemLimit { get; set; }
+
+    [JsonPropertyName("ytdl_options_presets")]
+    public string[] Presets { get; set; } = [];
 }

--- a/VideoDownloader/Client/MeTubeClient.cs
+++ b/VideoDownloader/Client/MeTubeClient.cs
@@ -36,7 +36,7 @@ public class MeTubeClient
         _httpClient.BaseAddress = baseUrl;
     }
 
-    public async Task<MeTubeGenericResponse?> AddDownload(string url, string idPrefix)
+    public async Task<MeTubeGenericResponse?> AddDownload(string url, string idPrefix, string[] presets)
     {
         var settings = _sqlConfigurationService.VideoDownloaderSettings;
         var requestBody = new MeTubeAddRequest
@@ -48,7 +48,8 @@ public class MeTubeClient
             DownloadType = "video",
             AutoStart = true,
             SplitByChapters = false,
-            CustomNamePrefix = idPrefix
+            CustomNamePrefix = idPrefix,
+            Presets = presets
         };
 
         var content = JsonContent.Create(requestBody);

--- a/VideoDownloader/VideoDownloader.csproj
+++ b/VideoDownloader/VideoDownloader.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.10" />
+    <PackageReference Include="TagLibSharp" Version="2.3.0" />
     <PackageReference Include="Telegram.Bot" Version="22.9.6" />
   </ItemGroup>
 

--- a/VideoDownloader/VideoProcessHandler.cs
+++ b/VideoDownloader/VideoProcessHandler.cs
@@ -68,10 +68,26 @@ public class VideoProcessHandler(ILogger<VideoProcessHandler> logger, TelegramBo
         try
         {
             using var response = await meTubeClient.GetFileResponseAsync(item.Filename!, cancellationToken);
-            using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+
+            using var ms = new MemoryStream();
+            await response.Content.CopyToAsync(ms, cancellationToken);
+            ms.Position = 0;
+
+            int? videoWidth = null, videoHeight = null;
+            try
+            {
+                using var tagFile = TagLib.File.Create(new StreamAbstraction(item.Filename!, ms));
+                videoWidth = tagFile.Properties.VideoWidth > 0 ? tagFile.Properties.VideoWidth : null;
+                videoHeight = tagFile.Properties.VideoHeight > 0 ? tagFile.Properties.VideoHeight : null;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Could not read video dimensions from {filename}", item.Filename);
+            }
+            ms.Position = 0;
 
             var chatId = new ChatId(job.ChatId);
-            var inputFile = InputFile.FromStream(stream, item.Filename);
+            var inputFile = InputFile.FromStream(ms, item.Filename);
 
             bool sendWithCaption = true;
             var caption = $"Відео від {job.RequestedBy}."
@@ -89,6 +105,8 @@ public class VideoProcessHandler(ILogger<VideoProcessHandler> logger, TelegramBo
             {
                 ChatId = chatId,
                 Video = inputFile,
+                Width = videoWidth,
+                Height = videoHeight,
                 MessageThreadId = job.MessageThreadId == 0 ? null : job.MessageThreadId,
                 Caption = caption,
                 ShowCaptionAboveMedia = true,
@@ -102,6 +120,7 @@ public class VideoProcessHandler(ILogger<VideoProcessHandler> logger, TelegramBo
                     ChatId = chatId,
                     Text = $"Повідомлення від {job.RequestedBy}:\n{job.UserComment}",
                     MessageThreadId = job.MessageThreadId == 0 ? null : job.MessageThreadId,
+                    DisableNotification = true,
                 }, cancellationToken);
             }
 
@@ -259,5 +278,13 @@ public class VideoProcessHandler(ILogger<VideoProcessHandler> logger, TelegramBo
         {
             logger.LogWarning(ex, "Could not edit status message {messageId}", job.BotMessage);
         }
+    }
+
+    private sealed class StreamAbstraction(string name, Stream stream) : TagLib.File.IFileAbstraction
+    {
+        public string Name { get; } = name;
+        public Stream ReadStream { get; } = stream;
+        public Stream WriteStream { get; } = stream;
+        public void CloseStream(Stream s) { }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 name: bober
 
 x-base-bot-service: &base-bot
+  volumes:
+    - ./ytdl-presets.json:/config/ytdl-presets.json
   restart: always
    
 x-base-db: &base-db
@@ -29,14 +31,15 @@ services:
       - dev
     volumes:
       - metube-downloads:/downloads
+      - ./ytdl-presets.json:/config/ytdl-presets.json
     image: ghcr.io/alexta69/metube
     ports:
         - "8082:8081"
     restart: always
     environment:
-      - 'YTDL_OPTIONS={"cookiesfrombrowser":null,"merge_output_format":"mp4","remux_video":"mp4","format":"mp4","format_sort":["vcodec:h264","lang","quality","res","fps","hdr:12","acodec:aac"]}'
+      - YTDL_OPTIONS_PRESETS_FILE=/config/ytdl-presets.json
       - DELETE_FILE_ON_TRASHCAN=true
-      - OUTPUT_TEMPLATE=%(title)s [%(id)s].%(ext)s
+
   bot:
     image: ghcr.io/natashalysakova/bober-bot:latest
     container_name: bot

--- a/ytdl-presets.json
+++ b/ytdl-presets.json
@@ -1,0 +1,34 @@
+{
+  "default": {
+    "outtmpl": "%(id)s.%(ext)s"
+  },
+
+  "youtube": {
+    "merge_output_format": "mp4",
+    "format": "mp4",
+    "format_sort": [
+      "vcodec:h264",
+      "lang",
+      "quality",
+      "res",
+      "fps",
+      "hdr:12",
+      "acodec:aac"
+    ]
+  },
+
+  "instagram": {
+    "merge_output_format": "mp4",
+    "format": "mp4",
+    "format_sort": [
+      "vcodec:h264",
+      "lang",
+      "quality",
+      "res",
+      "fps",
+      "hdr:12",
+      "acodec:aac"
+    ]
+  }
+
+}


### PR DESCRIPTION
- Add ytdl-presets.json for per-site yt-dlp options
- Pass relevant presets to MeTube based on video URL domain
- Mount presets file in both bot and MeTube containers
- Configure MeTube to use YTDL_OPTIONS_PRESETS_FILE
- Detect video width/height with TagLibSharp for Telegram uploads
- Improve error handling, logging, and notification settings
- Add TagLibSharp dependency