### PR TITLE
Update Magick.NET, add ytdl-presets config support

### DIFF
--- a/TelegramMultiBot/TelegramMultiBot.csproj
+++ b/TelegramMultiBot/TelegramMultiBot.csproj
@@ -21,8 +21,8 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.4.0" />
     <PackageReference Include="Cronos" Version="0.12.0" />
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.11.1" />
-    <PackageReference Include="Magick.NET.Core" Version="14.11.1" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.12.0" />
+    <PackageReference Include="Magick.NET.Core" Version="14.12.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.Build" Version="17.10.46" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="9.0.10" />

--- a/VideoDownloader/VideoProcessHandler.cs
+++ b/VideoDownloader/VideoProcessHandler.cs
@@ -404,6 +404,7 @@ public class VideoProcessHandler(ILogger<VideoProcessHandler> logger, TelegramBo
         }
     }
 
+    private static readonly string CongifPath = "/config/ytdl-presets.json";
 
     private string[] GetPresetList(string link)
     {
@@ -412,12 +413,17 @@ public class VideoProcessHandler(ILogger<VideoProcessHandler> logger, TelegramBo
         {
             "default"
         };
-        logger.LogInformation("Looking for presets for link={link}", link);
 
         var alias = GetLinkAlias(link);
         try
         {
-            var text = File.ReadAllText("/config/ytdl-presets.json");
+            if (!File.Exists(CongifPath))
+            {
+                logger.LogWarning("Preset file not found at {path}, using default preset only", CongifPath);
+                return result.ToArray();
+            }
+
+            var text = File.ReadAllText(CongifPath);
             logger.LogInformation(text);
 
             var json = JsonSerializer.Deserialize<JsonObject>(text);
@@ -425,12 +431,10 @@ public class VideoProcessHandler(ILogger<VideoProcessHandler> logger, TelegramBo
             {
                 result.Add(alias);
             }
-
-            logger.LogInformation("Found presets:{list}", string.Join(',', result));
         }
         catch (Exception ex)
         {
-            logger.LogError("Failed to read perset file: {error}", ex.Message);
+            logger.LogError("Failed to read preset file: {error}", ex.Message);
         }
 
         return result.ToArray();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - .env
     volumes:
       - images:/app/images
+      - ./ytdl-presets.json:/config/ytdl-presets.json
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
- Bump Magick.NET-Q16-AnyCPU and Core to v14.12.0
- Add check for ytdl-presets.json existence in VideoProcessHandler
- Log warning and use default preset if config is missing
- Mount ytdl-presets.json into container via docker-compose volume