### PR TITLE
Disable commands via attribute, improve video error handling

### DIFF
--- a/TelegramMultiBot/Commands/BaseCommand.cs
+++ b/TelegramMultiBot/Commands/BaseCommand.cs
@@ -140,3 +140,8 @@ internal sealed class ServiceKeyAttribute(string command, string description, bo
         get => isPublic;
     }
 }
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+internal sealed class DisabledAttribute() : Attribute
+{
+}

--- a/TelegramMultiBot/Commands/GptCommand.cs
+++ b/TelegramMultiBot/Commands/GptCommand.cs
@@ -7,6 +7,7 @@ using TelegramMultiBot.MessageCache;
 namespace TelegramMultiBot.Commands;
 
 [ServiceKey("gpt", "Задати питання ШІ")]
+[Disabled]
 internal class GptCommand(
     IAssistantDataService assistantDataService,
     TelegramClientWrapper clientWrapper,

--- a/TelegramMultiBot/Program.cs
+++ b/TelegramMultiBot/Program.cs
@@ -239,17 +239,21 @@ internal class Program
         return version;
     }
 
+    private static bool IsDisabled(Type type) =>
+        type.GetAttributeValue((DisabledAttribute c) => true);
+
     private static void RegisterMyKeyedServices<T>(IServiceCollection serviceCollection)
     {
-        var services = RegisterMyServices<T>(serviceCollection);
-        var types = GetTypes<T>();
+        var types = GetEnabledTypes<T>();
 
         foreach (var item in types)
         {
-            var key = item.GetAttributeValue((ServiceKeyAttribute c) => { return c.Command; });
+            _ = serviceCollection.AddTransient(typeof(T), item);
+
+            var key = item.GetAttributeValue((ServiceKeyAttribute c) => c.Command);
             if (key != null)
             {
-                _ = services.AddKeyedScoped(typeof(T), key, item);
+                _ = serviceCollection.AddKeyedScoped(typeof(T), key, item);
             }
         }
     }
@@ -257,18 +261,17 @@ internal class Program
     private static IEnumerable<Type> GetTypes<T>()
     {
         var type = typeof(T);
-        var types = AppDomain.CurrentDomain.GetAssemblies()
+        return AppDomain.CurrentDomain.GetAssemblies()
             .SelectMany(s => s.GetTypes())
             .Where(p => type.IsAssignableFrom(p) && !p.IsAbstract);
-
-        return types;
     }
+
+    private static IEnumerable<Type> GetEnabledTypes<T>() =>
+        GetTypes<T>().Where(t => !IsDisabled(t));
 
     public static IServiceCollection RegisterMyServices<T>(IServiceCollection serviceCollection)
     {
-        var services = GetTypes<T>();
-
-        foreach (var item in services)
+        foreach (var item in GetEnabledTypes<T>())
         {
             _ = serviceCollection.AddTransient(typeof(T), item);
         }

--- a/VideoDownloader/Client/MeTubeHistoryResponse.cs
+++ b/VideoDownloader/Client/MeTubeHistoryResponse.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Text.Json.Serialization;
 
 namespace VideoDownloader.Client;
@@ -12,4 +13,11 @@ public record MeTubeHistoryResponse
 
     [JsonPropertyName("pending")]
     public MeTubeHistoryItem[] Pending { get; set; } = [];
+
+    internal IEnumerable<string> GetAllIds()
+    {
+        return Done.Select(x => x.Id)
+            .Concat(Queue.Select(x => x.Id))
+            .Concat(Pending.Select(x => x.Id));
+    }
 }

--- a/VideoDownloader/VideoProcessHandler.cs
+++ b/VideoDownloader/VideoProcessHandler.cs
@@ -184,7 +184,7 @@ public class VideoProcessHandler(ILogger<VideoProcessHandler> logger, TelegramBo
     public static string GetFallbackUrl(string videoUrl)
     {
         if (videoUrl.Contains("instagram.com"))
-            return videoUrl.Replace("instagram.com", "kksave.com");
+            return videoUrl.Replace("instagram.com", "kksav.com");
         if (videoUrl.Contains("x.com"))
             return videoUrl.Replace("x.com", "fixupx.com");
         if (videoUrl.Contains("twitter.com"))
@@ -214,6 +214,10 @@ public class VideoProcessHandler(ILogger<VideoProcessHandler> logger, TelegramBo
             text = fallbackUrl;
             deleteOriginal = true;
         }
+        else if (errorMessage != null && errorMessage.Contains("There is no video in this post"))
+        {
+            text = "В посту нема відео";
+        }
         else
         {
             text = $"❌ Помилка завантаження відео\n{fallbackUrl}";
@@ -238,6 +242,7 @@ public class VideoProcessHandler(ILogger<VideoProcessHandler> logger, TelegramBo
         else
         {
             await EditStatusMessage(job, text, cancellationToken);
+            job.Status = VideoDownloadStatus.Failed;
         }
 
         if (itemId != null)
@@ -389,7 +394,6 @@ public class VideoProcessHandler(ILogger<VideoProcessHandler> logger, TelegramBo
             try
             {
                 db.VideoDownloads.Add(job);
-                await db.SaveChangesAsync(cancellationToken);
 
                 var response = await meTubeClient.AddDownload(link, id.ToString(), presets);
                 if (response?.Status != MeTubeStatus.Ok)
@@ -400,6 +404,10 @@ public class VideoProcessHandler(ILogger<VideoProcessHandler> logger, TelegramBo
             catch (Exception ex)
             {
                 await HandleFailedDownload(job, ex.Message, cancellationToken);
+            }
+            finally
+            {
+                await db.SaveChangesAsync(cancellationToken);
             }
         }
     }


### PR DESCRIPTION
Added DisabledAttribute to allow disabling commands/services via attribute and updated registration logic to skip them. Marked GptCommand as disabled. Improved VideoProcessHandler error messages, fixed Instagram fallback URL typo, and ensured job status and DB changes are handled correctly. Added GetAllIds() to MeTubeHistoryResponse.